### PR TITLE
docs: reduce information on front page, split into separate files

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ My setup has an attached NVME drive which will hold the copied photos but the co
 To allow many different types of output displays, output status will be published to MQTT topics, scripts will be provided to read from these topics and display the required output that the device can manage, allowing many/all of the devices to be running sided by side!
 One other thing that intrepid users may want to consider is adding alternative status output devices, e.g use a text to speech synth to output via a speaker or headphones.
 
+See [[the_software]] for more details
+
 ## Install the OS and configure
 
 Head over to [Raspberry PI](https://www.raspberrypi.com/software/) and grab the Raspberry PI Imager. Choose your device, the OS (Raspberry PI OS lite) and edit your settings to enter your WiFi details, the hostname you want the device to use and the ssh credentials you wish to use.
@@ -59,83 +61,33 @@ Hopefully this is the straight forwards bit, clone this repo onto your pi, into 
 ./installer.sh
 ```
 
+You will be prompted to enter a password (twice), this is for the SAMBA file sharing and is for the name of the user you are currently logged in as. Please remember this password!
+
 Hopefully that will do everything needed and the system will reboot and it will just work. Raise an issue on the repo if there are any problems and I will see if I can resolve them.
 
 If you make any changes to the connected displays run the `display_config.sh` script to make changes.
 
-## The code itself
 
-The main code that controls things is written in Python, mostly because the majority of the devices you can buy and attach to your Raspberry Pi have Python libraries and I did not want to start from scratch. Also it was an opportunity to write some python and hopefully improve things.
+## Using the system
 
-I decided from the start to use a messaging system for the displays, this way I would not need to constantly fiddle with the main code, inserting ifs and buts for another display. Adding a new display mechanism is straight forwards and separate to the main code and can be tested  
+Rebooting the system when it has been installed, will have the system up and running. Either connecting a camera (in storage mode) via USB or a suitable SD Card reader, such as the [Anker 2-in-1 USB 3.0 SD Card Reader](https://www.amazon.co.uk/gp/product/B00LFIXC8I) which also has micro SD card slots,
 
-## The software so far
+Copying will start automatically when a suitable card/device is connected, the display(s) will show the status until the copy is complete. You will then be prompted to remove the card and the system will return to waiting for another device to be connected.
 
-- **be_gnarly** - this is called from cron and starts up all the required scripts to run the system
-- **display_config.sh** - choose which of the display options you wish to use
-- **gnarly_status_basic** - mostly for testing, displays MQTT messages in the terminal
-- **gnarly_status_blinkt** - simple LED only status display 
-- **gnarly_status_curses** - more advanced terminal display, needs work to tidy it up and stop screen flashes/tearing
-- **gnarly_status_ledshim** - a longer simple LED only status display
-- **gnarly_status_mini_pitft** - a compact 5 line 135x240 pixel display HAT, currently the nicest way to display status 
-- **gnarly_status_pitft** - big sister to the mini above, a 240x240 pixel display HAT, currently the nicest way to display status - RECOMMENDED!
-- **gnarlypi** - the main code, this does the copying
-- **installer.sh** - the installer!
-- _start_displays.sh_ - this script will be created by `display_config.sh` 
-- **display_config.sh** - script to chose output displays, run as part of installer, creates _start_displays.sh_
-- _tests/test_mini_pitft.py_**_ - test the the mini_pitft is working
-- _test_status.py_ - test status displays by single step through a selection of MQTT messages
+### Copy speeds
 
-For extra testing, it is possible, by using [mqtt2jsonl](https://github.com/27escape/mqtt2jsonl), to record and replay the MQTT messages, in real-time, to simulate a complete copy of files from a USB to the storage device - very handy!
+Data should be read from a USB3 connected SD card reader around 180MB/s depending on your SD card and via a USB cable to your camera at about 25MB/s, so set aside plenty of time to copy! :)
 
+### Retrieving files
 
-## Copying files from your camera
+The system uses SAMBA to provide file sharing, allowing you to retrieve previously stored files. On your home network, you should be able to connect to using the host name of the system you created when building the system
 
-As mentioned above, I have a [Anker 2-in-1 USB 3.0 SD Card Reader](https://www.amazon.co.uk/gp/product/B00LFIXC8I) connected to my pi 5, this has standard and micro SD card slots, data should be read from this around 180MB/s depending on your SD card. It is possible to directly connect your camera via a USB cable (assuming it has USB) but the transfer rate is generally a lot lower, even when connected to USB3 ports, maybe around 25MB/s, so this should only be used in an emergency or when you have plenty of time or not may files to copy! :)
+I have not given much thought to documenting this step but you will need to connect as a registered user, with the username of your raspberrypi and the password you created during installation.
 
-## Improvements / TODO
+- Windows - [How to connect to Linux Samba shares from Windows](https://www.supportyourtech.com/articles/how-to-connect-to-smb-share-windows-11-a-step-by-step-guide/)
+- Mac/OSX [How to Connect Your macOS Device to an SMB Share](https://www.techrepublic.com/article/how-to-connect-your-macos-device-to-an-smb-share/)
+- Linux - given the range of options for file managers etc, I am not going to provide a link, you are competent enough to search the internet yourself 
 
-Interaction:
-- allow limited button presses, only when not copying from SD, can still use some of the '/photo' topics to give status of actions
-  - maybe 2 buttons as default, to give 3 interactions: A (as Yes), B (as No) and A+B (as C/Cancel/Back)
-  - [ ] delete files from USB? Only allow if ONE connected device, to ensure correct choice - difficult for cameras with multiple card slots - user needs to remove each card, needs confirmation step
-  - [ ] rsync to NAS/computer - target defined in some config file, check target available before attempt 
+## TODO
 
-During copy process:
-- extract image thumbnails for 
-- [ ] Create day/trip indexes to each file that can be accessed via Samba/smb shares
-  - Create folder for each day/trip with symlinks to the relevant images
-  - a complete re-index script, inc thumbnail extraction
-
-Management: 
-- [ ] Create web app for management
-  - [ ] view/delete images or block wipe
-  - [ ] investigate photo album software
-- [ ] investigate creating WiFi network, when away from home
-
-Getting files off device:
-- [ ] investigate USB Gadget mode for Pi Zero 2
-  - allows personal devices to connect to samba/photo album for edit/sharing images
-- [ ] Use buttons to trigger copying to NAS
-
-Device improvements:
-- [ ] power button for non PI 5 devices
-  - For devices that do not provide an off switch (nice shutdown), we will need to investigate options to replicate that, either with buttons provided by any display choice or by adding our own switch, this is especially important for the PI's without a power button, check out https://howchoo.com/pi/how-to-add-a-power-button-to-your-raspberry-pi/ for a solution to that issue 
-  - the [OnOff SHIM](https://thepihut.com/products/onoff-shim) _may_ be a solution but button placement is not ideal, a secondary button will need soldering, intial trials show it may conflict with the adafruit PiTFT displays
-
-- [ ] CFexpress? My cameras don't use these cards, so this would only be added if anyone else needs it, ideally its just another USB device and should read and copy fine, without any code changes
-
-
-Alternative all in one solutions:
-
-There are interesting things over at [ClockworkPi](https://www.clockworkpi.com/shop) that seem to be based on the CM4 compute modules, which would mean external USB for storage, but that could be fine and things do not have to be super fast :)
-
-Would the [Zero Terminal](https://n-o-d-e.net/zeroterminal3.html) be a nice all in one device? _It does not look like this has had development in years and I cannot figure out how to contact the developer_
-
-For the PI 5, the [KKSB 7" display case](https://thepihut.com/products/kksb-case-for-raspberry-pi-5-and-the-official-raspberry-pi-7-touchscreen) could be a nice but I would need to create the web app to provide display and control features.
-
-Little Bird Electronics used to have a nice [PI 3 display/keyboard combo](https://littlebirdelectronics.com.au/products/raspberry-pi-3-2b-zero-mini-portable-2-4ghz-wireless-touchpad-keyboard-with-backlight) _but it is no longer available_
-
-Something like the [Micro Journal rev 2](https://liliputing.com/micro-journal-rev-2-revamp-is-a-compact-word-processor-with-a-mechanical-keyboard-and-a-clamshell-design/) could work _but needs storage and SD card capabilities_
-
-[Planet Computers](https://www.www3.planetcom.co.uk/) may have a suitable device but would need to a USB hub to have bigger external storage. The Gemini and Cosmo models are kinda at the top end of the price range for what I am trying to achieve. _Not sure if they are still in operation_
+see [[TODO]]

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,0 +1,46 @@
+# Improvements / TODO
+
+Interaction:
+- allow limited button presses, only when not copying from SD, can still use some of the '/photo' topics to give status of actions
+  - maybe 2 buttons as default, to give 3 interactions: A (as Yes), B (as No) and A+B (as C/Cancel/Back)
+  - [ ] delete files from USB? Only allow if ONE connected device, to ensure correct choice - difficult for cameras with multiple card slots - user needs to remove each card, needs confirmation step
+  - [ ] rsync to NAS/computer - target defined in some config file, check target available before attempt 
+
+During copy process:
+- extract image thumbnails for 
+- [ ] Create day/trip indexes to each file that can be accessed via Samba/smb shares
+  - Create folder for each day/trip with symlinks to the relevant images
+  - a complete re-index script, inc thumbnail extraction
+
+Management: 
+- [ ] Create web app for management
+  - [ ] view/delete images or block wipe
+  - [ ] investigate photo album software
+- [ ] investigate creating WiFi network, when away from home
+
+Getting files off device:
+- [ ] investigate USB Gadget mode for Pi Zero 2
+  - allows personal devices to connect to samba/photo album for edit/sharing images
+- [ ] Use buttons to trigger copying to NAS
+
+Device improvements:
+- [ ] power button for non PI 5 devices
+  - For devices that do not provide an off switch (nice shutdown), we will need to investigate options to replicate that, either with buttons provided by any display choice or by adding our own switch, this is especially important for the PI's without a power button, check out https://howchoo.com/pi/how-to-add-a-power-button-to-your-raspberry-pi/ for a solution to that issue 
+  - the [OnOff SHIM](https://thepihut.com/products/onoff-shim) _may_ be a solution but button placement is not ideal, a secondary button will need soldering, intial trials show it may conflict with the adafruit PiTFT displays
+
+- [ ] CFexpress? My cameras don't use these cards, so this would only be added if anyone else needs it, ideally its just another USB device and should read and copy fine, without any code changes
+
+
+Alternative all in one solutions:
+
+There are interesting things over at [ClockworkPi](https://www.clockworkpi.com/shop) that seem to be based on the CM4 compute modules, which would mean external USB for storage, but that could be fine and things do not have to be super fast :)
+
+Would the [Zero Terminal](https://n-o-d-e.net/zeroterminal3.html) be a nice all in one device? _It does not look like this has had development in years and I cannot figure out how to contact the developer_
+
+For the PI 5, the [KKSB 7" display case](https://thepihut.com/products/kksb-case-for-raspberry-pi-5-and-the-official-raspberry-pi-7-touchscreen) could be a nice but I would need to create the web app to provide display and control features.
+
+Little Bird Electronics used to have a nice [PI 3 display/keyboard combo](https://littlebirdelectronics.com.au/products/raspberry-pi-3-2b-zero-mini-portable-2-4ghz-wireless-touchpad-keyboard-with-backlight) _but it is no longer available_
+
+Something like the [Micro Journal rev 2](https://liliputing.com/micro-journal-rev-2-revamp-is-a-compact-word-processor-with-a-mechanical-keyboard-and-a-clamshell-design/) could work _but needs storage and SD card capabilities_
+
+[Planet Computers](https://www.www3.planetcom.co.uk/) may have a suitable device but would need to a USB hub to have bigger external storage. The Gemini and Cosmo models are kinda at the top end of the price range for what I am trying to achieve. _Not sure if they are still in operation_

--- a/docs/the_software.md
+++ b/docs/the_software.md
@@ -1,0 +1,24 @@
+# The code itself
+
+The main code that controls things is written in Python, mostly because the majority of the devices you can buy and attach to your Raspberry Pi have Python libraries and I did not want to start from scratch. Also it was an opportunity to write some python and hopefully improve things.
+
+I decided from the start to use a messaging system for the displays, this way I would not need to constantly fiddle with the main code, inserting ifs and buts for another display. Adding a new display mechanism is straight forwards and separate to the main code and can be tested  
+
+## The software so far
+
+- **be_gnarly** - this is called from cron and starts up all the required scripts to run the system
+- **display_config.sh** - choose which of the display options you wish to use
+- **gnarly_status_basic** - mostly for testing, displays MQTT messages in the terminal
+- **gnarly_status_blinkt** - simple LED only status display 
+- **gnarly_status_curses** - more advanced terminal display, needs work to tidy it up and stop screen flashes/tearing
+- **gnarly_status_ledshim** - a longer simple LED only status display
+- **gnarly_status_mini_pitft** - a compact 5 line 135x240 pixel display HAT, currently the nicest way to display status 
+- **gnarly_status_pitft** - big sister to the mini above, a 240x240 pixel display HAT, currently the nicest way to display status - RECOMMENDED!
+- **gnarlypi** - the main code, this does the copying
+- **installer.sh** - the installer!
+- _start_displays.sh_ - this script will be created by `display_config.sh` 
+- **display_config.sh** - script to chose output displays, run as part of installer, creates _start_displays.sh_
+- _tests/test_mini_pitft.py_**_ - test the the mini_pitft is working
+- _test_status.py_ - test status displays by single step through a selection of MQTT messages
+
+For extra testing, it is possible, by using [mqtt2jsonl](https://github.com/27escape/mqtt2jsonl), to record and replay the MQTT messages, in real-time, to simulate a complete copy of files from a USB to the storage device - very handy!


### PR DESCRIPTION
Reduce the amount of reading a casual reader has to do to understand what this repo is about and how to use it